### PR TITLE
Add continuity correction to prevent p-value from being zero in permutation tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: clusrank
-Version: 1.0-3
+Version: 1.0-4
 Title: Wilcoxon Rank Tests for Clustered Data
 Description: Non-parametric tests (Wilcoxon rank sum test and Wilcoxon signed rank test)
        for clustered data documented in
@@ -7,11 +7,10 @@ Description: Non-parametric tests (Wilcoxon rank sum test and Wilcoxon signed ra
 Authors@R: c(person(given = "Wenjie", family = "Wang", role = c("cre", "ctb"),
                     email = "wang@wwenjie.org",
                     comment = c(ORCID = "0000-0003-0363-3180")),
-             person(given = "Yujing", family = "Jiang",
-                    email = "yujing.jiang@uconn.edu", role = "aut"),
+             person(given = "Yujing", family = "Jiang", role = "aut"),
              person(given = "Mei-Ling Ting", family = "Lee", role = "ctb"),
              person(given = "Jun", family = "Yan", role = "ctb",
-	            email = "jun.yan@uconn.edu"))
+    	            email = "jun.yan@uconn.edu"))
 License: GPL (>=3)
 Depends:
   R (>= 4.0)
@@ -24,4 +23,4 @@ LazyData: true
 URL: https://github.com/wenjie2wang/clusrank
 BugReports: https://github.com/wenjie2wang/clusrank/issues
 Encoding: UTF-8
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/amd.R
+++ b/R/amd.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,8 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
+
+
 #' CARMS scores
 #'
 #'A data set from a research on complement factor H R1210C rare variant

--- a/R/clusWilcox.R
+++ b/R/clusWilcox.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,6 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
 
 
 ##' Wilcoxon Rank Sum and Signed Rank Test for Clustered Data

--- a/R/clusranksum.R
+++ b/R/clusranksum.R
@@ -171,17 +171,9 @@ clusWilcox.test.ranksum.rgl.clus.exact <- function(x, cluster, group,
                                                             group.temp,
                                                             str.temp)
     }
-
-    w.ecdf <- ecdf(W.vec)
-
-    pval<- switch(alternative,
-                  less = w.ecdf(W),
-                  greater = 1 - w.ecdf(W),
-                  two.sided = 2 * min(w.ecdf(W), 1 - w.ecdf(W)))
+    pval <- perm_pvalue(W, W.vec, alternative)
     names(mu) <- "difference in locations"
-
     names(W) <- "W"
-
     result <- list(statistic = W, p.value = pval,
                    null.value = mu, alternative = alternative,
                    data.name = DNAME, method = METHOD,
@@ -189,11 +181,6 @@ clusWilcox.test.ranksum.rgl.clus.exact <- function(x, cluster, group,
                    nobs = n.obs)
     class(result) <- "ctest"
     return(result)
-
-
-
-
-
 }
 
 
@@ -557,29 +544,19 @@ clusWilcox.test.ranksum.rgl.sub.exact <- function(x, cluster, group,
                                                            cluster.temp,
                                                            group.temp, stratum)
     }
-
-        w.ecdf <- ecdf(W.vec)
-
-        pval<- switch(alternative,
-                      less = w.ecdf(W),
-                      greater = 1 - w.ecdf(W),
-                      two.sided = 2 * min(w.ecdf(W), 1 - w.ecdf(W)))
-        names(mu) <- "shift in location"
-        if (bal == TRUE) names(W) <- "W"
-        else names(W) = "Z"
-
-        result <- list(statistic = W, p.value = pval,
+    pval <- perm_pvalue(W, W.vec, alternative)
+    names(mu) <- "shift in location"
+    if (bal)
+        names(W) <- "W"
+    else
+        names(W) = "Z"
+    result <- list(statistic = W, p.value = pval,
                    null.value = mu, alternative = alternative,
                    data.name = DNAME, method = METHOD,
                    balance = bal, exact = exact, B = B,  nclus = n.clus,
                    nobs = n.obs)
-        class(result) <- "ctest"
-        return(result)
-
-
-
-
-
+    class(result) <- "ctest"
+    return(result)
 }
 
 
@@ -896,13 +873,8 @@ clusWilcox.test.ranksum.ds.exact <- function(x, cluster, group,
         grp.temp <- sample(group, n.obs)
         W.vec[i] <- clusWilcox.test.ranksum.ds.exact.1(x, cluster,
                                                       grp.temp, 0)
-
     }
-
-    w.ecdf <- ecdf(W.vec)
-    pval <- switch(alternative, less = w.ecdf(W),
-                   greater = 1 - w.ecdf(W),
-                   two.sided = 2 * min(w.ecdf(W), 1 - w.ecdf(W)))
+    pval <- perm_pvalue(W, W.vec, alternative)
     METHOD <- paste0(METHOD, " (Random Permutation)")
     names(mu) <- "difference in locations"
 

--- a/R/clusranksum.R
+++ b/R/clusranksum.R
@@ -1,6 +1,8 @@
-##################################################################################
+##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -14,8 +16,6 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
-
 
 
 clusWilcox.test.ranksum.rgl <- function(x, cluster, group, stratum,

--- a/R/clussignrank.R
+++ b/R/clussignrank.R
@@ -37,25 +37,16 @@ clusWilcox.test.signedrank.rgl.exact <- function(x, cluster,
     signrank <- ifelse(data$x > 0, 1, -1) * data$xrank
     data <- cbind(data, signrank)
     colnames(data)[4] <- "signrank"
-
     srksum <-  stats::aggregate(signrank ~ cluster, FUN = sum)[, 2]
-
-    T <- sum(data$signrank)
-
+    T0 <- sum(data$signrank)
     ind <- replicate(B, sample(c(1, -1), m, TRUE))
-
-    T.ecdf <- ecdf(colSums(ind * srksum))
-
-    pval <- switch(alternative,
-                   less = T.ecdf(T),
-                   greater = 1 - T.ecdf(T),
-                   two.sided = 2 * min(T.ecdf(T), 1 - T.ecdf(T)))
-
-    names(T) <- "T"
+    Ts <- colSums(ind * srksum)
+    pval <- perm_pvalue(T0, Ts, alternative)
+    names(T0) <- "T"
     names(n) <- "total number of observations"
     names(m) <- "total number of clusters"
     names(mu) <- "shift in location"
-    result <- list(statistic = T,
+    result <- list(statistic = T0,
                    p.value = pval, nobs = n, nclus = m, null.value = mu,
                    alternative = alternative,
                    data.name = DNAME, method = METHOD)
@@ -250,26 +241,19 @@ clusWilcox.test.signedrank.ds.exact <- function(x, cluster, alternative,
         x.samp <- abs(x) * sgn.samp
         T.vec[i] <- clusWilcox.test.signedrank.ds.exact.1(x.samp, cluster)
     }
-    T <- clusWilcox.test.signedrank.ds.exact.1(x, cluster)
-    t.ecdf <- ecdf(T.vec)
-
-    pval <- switch(alternative, less = t.ecdf(T),
-                   greater = 1 - t.ecdf(T),
-                   two.sided = 2 * min(t.ecdf(T), 1 - t.ecdf(T)))
-
+    T0 <- clusWilcox.test.signedrank.ds.exact.1(x, cluster)
+    pval <- perm_pvalue(T0, T.vec, alternative)
     names(n.obs) <- "total number of observations"
     names(n.clus) <- "total number of clusters"
-    names(T) <- "T"
+    names(T0) <- "T"
     names(mu) <- "shift in location"
-    result <- list(statistic = T,
+    result <- list(statistic = T0,
                    p.value = pval, nobs = n.obs, nclus = n.clus,
                    alternative = alternative,
                    null.value = mu,
                    data.name = DNAME, method = METHOD)
     class(result) <- "ctest"
     return(result)
-
-
 }
 
 

--- a/R/clussignrank.R
+++ b/R/clussignrank.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,8 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
+
+
 clusWilcox.test.signedrank.rgl.exact <- function(x, cluster,
                                                 alternative,
                                                 mu, B, DNAME, METHOD) {

--- a/R/crd.R
+++ b/R/crd.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,8 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
+
+
 #' Clustered Non-Stratified Data for Testing Clustered Rank Sum Test
 #'
 #' Non-stratified data including 3 variables:

--- a/R/crdstr.R
+++ b/R/crdstr.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,8 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
+
+
 #' Clustered Stratified Data for Testing the Clustered Rank Sum Test
 #'
 #' Stratified data with clustering structure, Have some missing values.

--- a/R/crsd.R
+++ b/R/crsd.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,8 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
+
+
 #'  Difference Between Pre and Post Treatment Scores with Clustering
 #'  Structure: Balanced
 #'

--- a/R/crsdunb.R
+++ b/R/crsdunb.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,8 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
+
+
 #'  Difference between Pre and Post Treatment Scores with Clustering
 #'  Structure: Unbalanced
 #'

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,3 +1,23 @@
+##
+## clusrank: Wilcoxon Rank Tests for Clustered Data
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
+##
+## This file is part of the R package clusrank.
+##
+## The R package clusrank is free software: You can redistribute it and/or
+## modify it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or any later
+## version (at your option). See the GNU General Public License at
+## <https://www.gnu.org/licenses/> for details.
+##
+## The R package clusrank is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+##
+
+
 ## returns the p-value for permutation tests
 perm_pvalue <- function(w0, ws, alternative)
 {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,0 +1,13 @@
+## returns the p-value for permutation tests
+perm_pvalue <- function(w0, ws, alternative)
+{
+    ## continuity correction to prevent p-value from being exactly zero
+    prob_le_w <- (sum(ws <= w0) + 0.5) / (length(ws) + 1)
+    switch(
+        alternative,
+        two.sided = 2 * min(prob_le_w, 1 - prob_le_w),
+        greater = 1 - prob_le_w,
+        less = prob_le_w,
+        stop("Unknown alternative.")
+    )
+}

--- a/R/pairwise.clusWilcox.test.R
+++ b/R/pairwise.clusWilcox.test.R
@@ -1,6 +1,8 @@
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2016-2021  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##

--- a/R/print.R
+++ b/R/print.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,6 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
 
 
 #' @keywords internal

--- a/R/recodeFun.R
+++ b/R/recodeFun.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,8 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
+
+
 recoderFunc <- function(data, oldvalue, newvalue) {
 
     ## convert any factors to characters

--- a/R/special.R
+++ b/R/special.R
@@ -1,7 +1,8 @@
-################################################################################
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2015-2022  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##
@@ -15,7 +16,6 @@
 ## but WITHOUT ANY WARRANTY without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-################################################################################
 
 
 #' Identify clusters

--- a/misc/copyright.R
+++ b/misc/copyright.R
@@ -1,6 +1,8 @@
 ##
 ## clusrank: Wilcoxon Rank Tests for Clustered Data
-## Copyright (C) 2016-2021  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+##
+## Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+## Copyright (C) 2022-2023 Wenjie Wang
 ##
 ## This file is part of the R package clusrank.
 ##

--- a/misc/update_timestamp.sh
+++ b/misc/update_timestamp.sh
@@ -17,7 +17,7 @@ then
     version=$(grep "Version" DESCRIPTION | awk '{print $NF}')
 
     # update copyright year in the template headers
-    regexp1="s/Copyright \(C\) 2015-[0-9]+/Copyright \(C\) 2015-$yr/"
+    regexp1="s/Copyright \(C\) 20([0-9]{2})-[0-9]+/Copyright \(C\) 20\1-$yr/"
     sed -i.bak -E "$regexp1" $cprt_R && rm $cprt_R.bak
     sed "s_#_/_g" $cprt_R > $cprt_cpp
 

--- a/src/Fprop.cpp
+++ b/src/Fprop.cpp
@@ -1,6 +1,8 @@
 //
 // clusrank: Wilcoxon Rank Tests for Clustered Data
-// Copyright (C) 2016-2021  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+//
+// Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+// Copyright (C) 2022-2023 Wenjie Wang
 //
 // This file is part of the R package clusrank.
 //
@@ -14,6 +16,7 @@
 // but WITHOUT ANY WARRANTY without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 //
+
 
 
 #include <Rcpp.h>

--- a/src/exact.cpp
+++ b/src/exact.cpp
@@ -1,6 +1,8 @@
 //
 // clusrank: Wilcoxon Rank Tests for Clustered Data
-// Copyright (C) 2016-2021  Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+//
+// Copyright (C) 2015-2023 Yujing Jiang, Mei-Ling Ting Lee, and Jun Yan
+// Copyright (C) 2022-2023 Wenjie Wang
 //
 // This file is part of the R package clusrank.
 //
@@ -14,6 +16,7 @@
 // but WITHOUT ANY WARRANTY without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 //
+
 
 
 #include <Rcpp.h>

--- a/tests/testrun.R
+++ b/tests/testrun.R
@@ -1,6 +1,7 @@
-
-
 library(clusrank)
+packageVersion("clusrank")
+set.seed(123)
+
 data(crsd)
 clusWilcox.test(z, cluster = id, data = crsd, paired = TRUE, method = "rgl")
 clusWilcox.test(z, cluster = id, data = crsd, paired = TRUE, method = "rgl", alternative = "greater", mu = 1)


### PR DESCRIPTION
See 2a388597d953e3bac2126a3975bf861489a8c696 for the essential changes.

## Current version on CRAN

```r
w.ecdf <- ecdf(W.vec)
pval<- switch(alternative,
              less = w.ecdf(W),
              greater = 1 - w.ecdf(W),
              two.sided = 2 * min(w.ecdf(W), 1 - w.ecdf(W)))
```

## Proposed in this PR

```r
pval <- perm_pvalue(W, W.vec, alternative)
```

where the function `perm_pvalue()` is as follows: 
https://github.com/wenjie2wang/clusrank/blob/299d5dee4e11d81d1faa2cc619c7ce6d8c224a41/R/helpers.R#L21-L33